### PR TITLE
Add support for BotMan v2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "botman/botman": "~2.5.0",
+    "botman/botman": "^2.5",
     "php": ">=7.1",
     "charlottedunois/yasmin": "~v0.6",
     "illuminate/support": "^6.0"


### PR DESCRIPTION
This will add support for BotMan v2.6.

I couldn't install this package with a fresh install of `botman/botman`.